### PR TITLE
Refactor alert description handling to use truncateString for improve…

### DIFF
--- a/weatherCrow5.7/weatherCrow5.7.ino
+++ b/weatherCrow5.7/weatherCrow5.7.ino
@@ -816,10 +816,8 @@ private:
     {
       String desc = removeWarningDescription(alert["description"].as<String>());
 
-      if (desc.length() > STRING_BUFFER_SIZE - 5)
-      {
-        desc = desc.substring(0, STRING_BUFFER_SIZE - 5) + "...";
-      }
+      int maxLength = 200; // Maximum length for description
+      desc = truncateString(desc, maxLength);
 
       memset(buffer, 0, sizeof(buffer));
       snprintf(buffer, sizeof(buffer), "%s", desc.c_str());


### PR DESCRIPTION
Limit alert description length to 200. 
it should fix the overlapping texts.